### PR TITLE
added shipped status in the sales order

### DIFF
--- a/netSuiteDev/src/FileCabinet/SuiteScripts/FullfilmentChecked.js
+++ b/netSuiteDev/src/FileCabinet/SuiteScripts/FullfilmentChecked.js
@@ -1,0 +1,68 @@
+/**
+ * @NApiVersion 2.1
+ * @NScriptType UserEventScript
+ */
+define(['N/log', 'N/record'],
+    /**
+ * @param{log} log
+ * @param{record} record
+ */
+    (log, record) => {
+
+        const afterSubmit = (context) => {
+            const thisRecord = context.newRecord;
+            // get the status of the order on the item fulfillment page if it is shipped
+            const shipStatus = thisRecord.getValue({
+                fieldId: 'shipstatus'
+            })
+            log.debug('ship Status', shipStatus);
+
+            if (shipStatus !== 'C'){
+                return
+            }
+            // get the value of the sublist line on the item fulfillment page and loop through and push it in the array
+
+            const orderLineArray = []
+            const iFulLineCount = thisRecord.getLineCount({sublistId:'item'});
+            for (let i=0; i<iFulLineCount; i++){
+                const orderLine = thisRecord.getSublistValue({
+                    sublistId: 'item',
+                    fieldId: 'orderline',
+                    line: i
+                })
+                orderLineArray.push(orderLine)
+            }
+
+            const salesOrderID = thisRecord.getValue({
+             fieldId: 'createdfrom'
+            })
+            const salesOrderPage = record.load({
+                type: 'salesorder',
+                id: salesOrderID
+            })
+            log.debug('sales order ID', salesOrderID)
+            const lineCount = salesOrderPage.getLineCount({sublistId:'item'})
+            for (let i=0; i<lineCount; i++){
+                const soLine = salesOrderPage.getSublistValue({
+                    sublistId: 'item',
+                    fieldId: 'line',
+                    line: i
+                });
+                if (orderLineArray.includes(soLine) === true){
+                    salesOrderPage.setSublistValue({
+                        sublistId: 'item',
+                        fieldId: 'custcol_fulfillment_shipped',
+                        line: i,
+                        value: true
+                    })
+                }
+
+            }
+
+            salesOrderPage.save()
+            return true
+        }
+
+        return {afterSubmit}
+
+    });

--- a/netSuiteDev/src/FileCabinet/SuiteScripts/savedSearch.js
+++ b/netSuiteDev/src/FileCabinet/SuiteScripts/savedSearch.js
@@ -73,7 +73,6 @@ define(['N/record', 'N/log', 'N/search'],
                 loadSalesOrder.setValue({
                     fieldId: 'memo',
                     value: customerCommentsId
-
                 })
                 loadSalesOrder.save()
                 return true;

--- a/netSuiteDev/src/FileCabinet/SuiteScripts/savedSearch2.js
+++ b/netSuiteDev/src/FileCabinet/SuiteScripts/savedSearch2.js
@@ -1,0 +1,56 @@
+/**
+ * @NApiVersion 2.1
+ * @NScriptType UserEventScript
+ */
+define(['N/record', 'N/log', 'N/search'],
+
+    function(record, log, search) {
+
+
+        const afterSubmit = (context) => {
+        //         get value of comments on customer record page
+                const thisRecord = context.newRecord
+                const customerId = thisRecord.id
+                const customerComments = thisRecord.getValue({
+                        fieldId: 'comments'
+                })
+
+                const salesorderSearchObj = search.create({
+                        type: "salesorder",
+                        filters:
+                            [
+                                    ["mainline","is","T"],
+                                    "AND",
+                                    ["type","anyof","SalesOrd"],
+                                    "AND",
+                                    ["name","anyof",customerId]
+                            ],
+                        columns:
+                            [
+                                    "internalid",
+                                    "tranid",
+                            ]
+                });
+                salesorderSearchObj.run().each(function(result){
+                        // .run().each has a limit of 4,000 results
+                    log.debug('saved search sales order', result)
+                    const orderId = result.getValue({
+                        name: 'tranid'
+                    })
+                    log.debug('orderId', orderId)
+                    const salesOrderPage = record.load({
+                        type: 'salesorder',
+                        id: result.id,
+                    })
+                    salesOrderPage.setValue({
+                        fieldId: 'memo',
+                        value: customerComments
+                    })
+                    salesOrderPage.save()
+                        return true;
+                });
+        }
+
+        return {afterSubmit}
+
+    });


### PR DESCRIPTION
When an Item Fulfillment is shipped (There are three stages of Item Fulfillment - Pick, Packed, Shipped) then set the lines on the Sales Order for which lines are on that Item Fulfillment. There is a sublist field called “orderline” on the Item Fulfillment which maps to the “line” sublist field on the Sales Order. Use the field explorer extension you have on your browser to explore this. In other words, once the Item Fulfillment is shipped, match the lines on the fulfillment to the Sales Order and set the new checkbox you created on the line. Multiple Item Fulfillments can be created for Sales Orders, that’s why you need to match the lines rather than set all the lines on the SO.